### PR TITLE
Change text string to be translated to UTF-8 encoding.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -82,7 +82,7 @@ class Translator(object):
             supported category is "general".
         """
         params = {
-            'text': text,
+            'text': text.encode('utf8'),
             'to': to_lang,
             'contentType': content_type,
             'category': category,


### PR DESCRIPTION
In the `translate()` function, I changed text to be translated in the parameters dictionary to UTF-8 encoding. I needed this to allow Japanese strings to be translated. Otherwise, `urlencode()` in the `call()` function would fail with a UnicodeEncode exception.

This change does not have any affect on legacy ASCII strings.
