### PR TITLE
Support unicode json responses

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -18,6 +18,7 @@ except ImportError:
     import json
 
 import requests
+import six
 import warnings
 import logging
 
@@ -126,15 +127,15 @@ class Translator(object):
         resp.encoding = 'UTF-8-sig'
         rv = resp.json()
 
-        if isinstance(rv, (str, unicode)) and \
+        if isinstance(rv, six.string_types) and \
                 rv.startswith("ArgumentOutOfRangeException"):
             raise ArgumentOutOfRangeException(rv)
 
-        if isinstance(rv, (str, unicode)) and \
+        if isinstance(rv, six.string_types) and \
                 rv.startswith("TranslateApiException"):
             raise TranslateApiException(rv)
 
-        if isinstance(rv, (str, unicode)) and \
+        if isinstance(rv, six.string_types) and \
                 rv.startswith(("ArgumentException: "
                                "The incoming token has expired")):
             self.access_token = None

--- a/setup.py
+++ b/setup.py
@@ -64,5 +64,6 @@ setup(
     test_suite="microsofttranslator.test.test_all",
     install_requires=[
         'requests >= 1.2.3',
+        'six',
     ]
 )


### PR DESCRIPTION
Expiring tokens weren't being handled because the response type comparison was failing. This fix now handles token expiration correctly.
