### PR TITLE
Added encoding to open file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,8 @@ from setuptools import setup
 
 
 def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname), encoding='utf-8').read()
+    f = open(os.path.join(os.path.dirname(__file__), fname), encoding='utf-8')
+    return f.read()
 
 setup(
     name="microsofttranslator",


### PR DESCRIPTION
On Windows machines your package can not be installed via pip, so I added utf-8 encoding:

``` python
File "C:\Users\me\AppData\Local\Temp\foo-packaging587492447920215615.tmp\microsofttranslator\setup.py", line 34, in read
    return open(os.path.join(os.path.dirname(__file__), fname)).read()
File "C:\Python34\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 1377: character maps to <undefined>
```
