### PR TITLE
Fixed failure to install on systems where locale is not UTF-8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ from setuptools import setup
 
 
 def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+    return open(os.path.join(os.path.dirname(__file__), fname), 'rb').read().decode('utf-8')
 
 setup(
     name="microsofttranslator",


### PR DESCRIPTION
In Python 3 open() defaults to reading in text mode in the default locale
for the system. This causes an exception if the default locale encoding
is ASCII, since the README.rst file is UTF-8 and not valid ASCII.
The encoding can't be specified in the call to open() since this would
not be valid Python 2.

I hit this problem while trying to install under python 3 in a dokku project.
