### PR TITLE
docs: fix simple typo, micrsoft -> microsoft

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -2,7 +2,7 @@
 """
     __init__
 
-    A translator using the micrsoft translation engine documented here:
+    A translator using the microsoft translation engine documented here:
 
     http://msdn.microsoft.com/en-us/library/ff512419.aspx
 


### PR DESCRIPTION
There is a small typo in __init__.py.

Should read `microsoft` rather than `micrsoft`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md